### PR TITLE
Add cert-manager annotation to Grafana ingress

### DIFF
--- a/kube-prometheus-stack/values.yaml
+++ b/kube-prometheus-stack/values.yaml
@@ -90,6 +90,7 @@ grafana:
       {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+      # cert-manager.io/cluster-issuer: letsencrypt-prod
 
     ## Labels to be added to the Ingress
     ##
@@ -98,15 +99,15 @@ grafana:
     ## Hostnames.
     ## Must be provided if Ingress is enabled.
     ##
-    # hosts:
-    #   - grafana.domain.com
     hosts: []
+      # - grafana.domain.com
 
     ## Path for grafana ingress
     path: /
 
     ## TLS configuration for grafana Ingress
-    ## Secret must be manually created in the namespace
+    ## Secret must either be manually created in the namespace or
+    ## a ClusterIssuer with the name provided should be defined above
     ##
     tls: []
     # - secretName: grafana-general-tls


### PR DESCRIPTION
In the default `kube-prometheus-stack` helm chart, the user is informed about the need to get a certificate for the Grafana ingress themselves. As in other Theia helm charts, it's way more comfortable to have `cert-manager` retrieve a valid certificate automatically.
This PR adds the respective annotation to the values making it easy for new users to recognize the solution and use it.

Tested using `letsencrypt-prod` on a TUM K8s cluster.